### PR TITLE
Change to use lowercase a in #include activeFrameQML.h

### DIFF
--- a/BfB-Boilerplate-10.2/src/activeFrameQML.cpp
+++ b/BfB-Boilerplate-10.2/src/activeFrameQML.cpp
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include "ActiveFrameQML.h"
+#include "activeFrameQML.h"
 #include <bb/cascades/Container>
 #include <bb/cascades/Application>
 

--- a/BfB-Boilerplate-10.2/src/applicationui.cpp
+++ b/BfB-Boilerplate-10.2/src/applicationui.cpp
@@ -15,7 +15,7 @@
 #include "applicationui.hpp"
 
 #include "bbm/BBMHandler.hpp"
-#include "ActiveFrameQML.h"
+#include "activeFrameQML.h"
 
 #include <bb/cascades/Application>
 #include <bb/cascades/QmlDocument>


### PR DESCRIPTION
I just tried out the Cascade-Samples/BfB-Boilerplate-10.2 and ran into a very minor bug due to two upper-case A's.  This should patch it.
