### PR TITLE
MultiCover typo fix

### DIFF
--- a/cascadescookbookcpp/src/cascadescookbookapp.cpp
+++ b/cascadescookbookcpp/src/cascadescookbookapp.cpp
@@ -75,7 +75,7 @@
 #include <bb/cascades/ThemeSupport>
 #include <bb/cascades/TitleBar>
 #include <bb/cascades/VisualStyle>
-#include <bb/cascades/Multicover>
+#include <bb/cascades/MultiCover>
 #include <bb/cascades/ApplicationViewCover>
 
 #include <bb/system/SystemToast>


### PR DESCRIPTION
#include bb/cascades/Multicover needs to be changed to #include bb/cascades/MultiCover to compile with SDK 10.3.1